### PR TITLE
Set device_info to unsynced on disconnect

### DIFF
--- a/pynecil/__init__.py
+++ b/pynecil/__init__.py
@@ -1,6 +1,6 @@
 """Pynecil - Python library to communicate with Pinecil V2 soldering irons via Bluetooth."""
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 from .client import Pynecil, discover
 from .exceptions import CommunicationError

--- a/pynecil/client.py
+++ b/pynecil/client.py
@@ -106,6 +106,7 @@ class Pynecil:
         def _disconnected_callback(client: BleakClient) -> None:
             _LOGGER.debug("Disconnected from %s", client.address)
             self.client_disconnected = True
+            self.device_info.is_synced = False
 
         self._client = BleakClient(
             address_or_ble_device,


### PR DESCRIPTION
Invalidate cached device_info on disconnect, as it may have changed in the meanwhile, like after a firmware update