### PR TITLE
Fix bug in power limit decimal placing

### DIFF
--- a/pynecil/client.py
+++ b/pynecil/client.py
@@ -6,6 +6,7 @@ import asyncio
 import hashlib
 import logging
 import struct
+from math import floor
 from typing import TYPE_CHECKING, Any, cast
 
 from bleak import BleakClient, BleakScanner
@@ -723,9 +724,9 @@ CHAR_MAP: dict[Characteristic, tuple] = {
     ),
     CharSetting.POWER_LIMIT: (
         const.CHAR_UUID_SETTINGS_POWER_LIMIT,
-        lambda x: decode_int(x) / 10,
-        lambda x: int(x * 10),
-        lambda x: clip(x, 0, 120),
+        lambda x: decode_int(x),
+        int,
+        lambda x: clip(floor(x / 5) * 5, 0, 120),
     ),
     CharSetting.INVERT_BUTTONS: (
         const.CHAR_UUID_SETTINGS_INVERT_BUTTONS,

--- a/pynecil/types.py
+++ b/pynecil/types.py
@@ -346,8 +346,8 @@ class SettingsDataResponse(TypedDict, total=False):
         Boost mode set point temperature (in °C, 0-450)
     calibration_offset: int | None
         Calibration offset for the installed tip (in µV, 100-2500)
-    power_limit: float | None
-        Maximum power allowed to output (in W, 0-12W, step=0.1)
+    power_limit: int | None
+        Maximum power allowed to output (in W, 0-120W, step=5)
     invert_buttons: bool | None
         Change the plus and minus button assigment
     temp_increment_long: int | None
@@ -407,7 +407,7 @@ class SettingsDataResponse(TypedDict, total=False):
     voltage_div: int | None
     boost_temp: int | None
     calibration_offset: int | None
-    power_limit: float | None
+    power_limit: int | None
     invert_buttons: bool | None
     temp_increment_long: int | None
     temp_increment_short: int | None


### PR DESCRIPTION
Fixes power limit wrongfully being converted to float (0.0-12.0W) with 1 decimal place. Correct value is integer 0-120W without decimals. Additionally adjusts to step size of 5W like used in the GUI