### PR TITLE
Improve CI workflow and extend test matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,29 +4,26 @@ on: [push, pull_request]
 
 jobs:
   test:
-
-    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_version: ['3.12']
-
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v5
-    - name: Set up Python
-      uses: actions/setup-python@v6
+    - uses: actions/setup-python@v6
       with:
-        python-version: ${{ matrix.python_version }}
+        python-version: '3.13' 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install "click==8.2.1" hatch
-        hatch env create
+        pipx install hatch --python python3.13
+        pipx inject hatch click==8.2.1 --force
     - name: Lint and typecheck
       run: |
         hatch run lint-check
     - name: Test
       run: |
-        hatch run test-cov-xml
+        hatch test --all
+
     - uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -44,15 +41,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v5
-    - name: Set up Python
-      uses: actions/setup-python@v6
-      with:
-        python-version: '3.13'
     - name: Install dependencies
       shell: bash
-      run: |
-        python -m pip install --upgrade pip
-        pip install hatch
+      run: pipx install hatch
     - name: mint API token
       id: mint-token
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ exclude_lines = [
 ]
 
 [tool.ruff]
-target-version = "py312"
+target-version = "py313"
 
 [tool.ruff.lint]
 extend-select = ["I", "TRY", "UP", "D", "W"]
@@ -26,7 +26,7 @@ commit_extra_args = ["-e"]
 path = "pynecil/__init__.py"
 
 [tool.hatch.envs.default]
-python = "3.12"
+python = "3.13"
 installer = "uv"
 dependencies = [
     "aiohttp==3.12.15",
@@ -40,6 +40,18 @@ dependencies = [
     "mkdocstrings[python]==0.30.0",
     "pytest-asyncio==1.1.0",
 ]
+
+[tool.hatch.envs.hatch-test]
+parallel = true
+extra-dependencies = [
+  "pytest-asyncio==1.1.0",
+  "pytest-cov==6.2.1",
+]
+extra-args = ["--cov-report=xml", "-vv"]
+type = "virtual"
+
+[[tool.hatch.envs.hatch-test.matrix]]
+python = ["3.13", "3.12", "3.11", "3.10"]
 
 [tool.hatch.envs.default.scripts]
 test = "pytest"


### PR DESCRIPTION
- Run tests on ubuntu-latest, windows-latest and macos-latest
- Run tests on Python 3.10, 3.11, 3.12, 3.13
- Install hatch with pipx