### PR TITLE
Pin click to v8.1.6 in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install hatch
+        python -m pip install "click==8.2.1" hatch
         hatch env create
     - name: Lint and typecheck
       run: |


### PR DESCRIPTION
Latest version of click breaks CI (click==8.3.0)